### PR TITLE
Get user from request, don't require

### DIFF
--- a/api/v2/views/access_token.py
+++ b/api/v2/views/access_token.py
@@ -31,11 +31,7 @@ class AccessTokenViewSet(AuthModelViewSet):
         issuer_backend = request.session.get('_auth_user_backend', '').split('.')[-1]
         data = request.data
         name = data.get('name', None)
-        atmo_user = data.get('atmo_user', None)
-        if not atmo_user:
-            return invalid_auth("atmo_user missing")
-
-        user = AtmosphereUser.objects.get(id=atmo_user)
+        user = request.user
         access_token = create_access_token(user, name, issuer=issuer_backend)
         json_response = {
             'token': access_token.token_id,


### PR DESCRIPTION
User id can be found server side on the request object and so is not required on the api request 